### PR TITLE
Hide window on close on MacOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,9 @@ function handleClosed() {
 }
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  if (process.platform === 'darwin') {
+    app.hide();
+  } else {
     app.quit();
   }
 });


### PR DESCRIPTION
In MacOS, its expected behavior that closing the window (Cmd+W) will return you to the last application. Currently, the app will remain "Focused" with no window. This PR fixes the behavior.