### PR TITLE
Fix icon asset path for Linux builds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "electron .",
     "build": "npm run build:macos && npm run build:linux && npm run build:windows",
     "build:macos": "electron-packager . --overwrite --asar --out=dist --ignore='^/(dist|assets)$' --platform=darwin --arch=x64 --icon=assets/icon.icns --app-bundle-id=com.andrepolischuk.keep && cd dist/Keep-darwin-x64 && zip -ryXq9 ../Keep-macos-${npm_package_version}.zip Keep.app",
-    "build:linux": "electron-packager . --overwrite --out=dist --ignore='^/(dist|assets)$' --platform=linux --arch=x64 --icon=assets/icon.png --app-bundle-id=com.andrepolischuk.keep && cd dist/Keep-linux-x64 && zip -ryq9 ../Keep-linux-${npm_package_version}.zip *",
+    "build:linux": "electron-packager . --overwrite --out=dist --ignore='^/(dist)$' --platform=linux --arch=x64 --app-bundle-id=com.andrepolischuk.keep && cd dist/Keep-linux-x64 && zip -ryq9 ../Keep-linux-${npm_package_version}.zip *",
     "build:windows": "electron-packager . --overwrite --asar --out=dist --ignore='^/(dist|assets)$' --platform=win32 --arch=ia32 --icon=assets/icon.ico --version-string.ProductName=$npm_package_productName && cd dist/Keep-win32-ia32 && zip -ryq9 ../Keep-windows-${npm_package_version}.zip *",
     "test": "standard"
   },

--- a/window.js
+++ b/window.js
@@ -12,7 +12,7 @@ module.exports = function createMainWindow (handleResize, handleClosed) {
     y: lastWindowState.y,
     width: lastWindowState.width,
     height: lastWindowState.height,
-    icon: join(__dirname, '../assets/icon.png'),
+    icon: join(__dirname, 'assets/icon.png'),
     title: 'Keep',
     titleBarStyle: 'hidden-inset',
     webPreferences: {


### PR DESCRIPTION
It seems like the `electron-packager` ignores the `--icon=assets/icon.png` flag for Linux builds. I removed this flag.

Also, I think that the `icon` path specified for the window is incorrect.

I was able to get the dock icon to appear in Linux builds by modifying the `icon` path parameter and un-ignoring the `assets` directory.

