### PR TITLE
Added spellcheck functionality using electron-spellchecker library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
   - 'node'
+addons:
+  apt:
+    packages:
+    - libx11-dev
+    - libxkbfile-dev

--- a/browser.js
+++ b/browser.js
@@ -54,6 +54,27 @@ function handleNavigate (event, hash) {
   window.location.hash = hash
 }
 
+const electronSpellchecker = window.require('electron-spellchecker');
+
+function loadSpellChecker() {
+       if (window.require) {
+         const SpellCheckHandler = electronSpellchecker.SpellCheckHandler;
+         const ContextMenuListener = electronSpellchecker.ContextMenuListener;
+         const ContextMenuBuilder = electronSpellchecker.ContextMenuBuilder;
+
+         window.spellCheckHandler = new SpellCheckHandler();
+         window.spellCheckHandler.attachToInput();
+         window.spellCheckHandler.switchLanguage('en-US');
+
+         let contextMenuBuilder = new ContextMenuBuilder(window.spellCheckHandler);
+
+         let contextMenuListener = new ContextMenuListener((info) => {
+             contextMenuBuilder.showPopupMenu(info);
+         });
+       }
+}
+
 window.addEventListener('DOMContentLoaded', handleDOMLoaded, false)
 window.addEventListener('click', handleClick, false)
+window.addEventListener('load', function () { loadSpellChecker() } );
 ipc.on('navigate', handleNavigate)

--- a/browser.js
+++ b/browser.js
@@ -54,27 +54,27 @@ function handleNavigate (event, hash) {
   window.location.hash = hash
 }
 
-const electronSpellchecker = window.require('electron-spellchecker');
+const electronSpellchecker = window.require('electron-spellchecker')
 
-function loadSpellChecker() {
-       if (window.require) {
-         const SpellCheckHandler = electronSpellchecker.SpellCheckHandler;
-         const ContextMenuListener = electronSpellchecker.ContextMenuListener;
-         const ContextMenuBuilder = electronSpellchecker.ContextMenuBuilder;
+function loadSpellChecker () {
+  if (window.require) {
+    const SpellCheckHandler = electronSpellchecker.SpellCheckHandler
+    const ContextMenuListener = electronSpellchecker.ContextMenuListener
+    const ContextMenuBuilder = electronSpellchecker.ContextMenuBuilder
 
-         window.spellCheckHandler = new SpellCheckHandler();
-         window.spellCheckHandler.attachToInput();
-         window.spellCheckHandler.switchLanguage('en-US');
+    window.spellCheckHandler = new SpellCheckHandler()
+    window.spellCheckHandler.attachToInput()
+    window.spellCheckHandler.switchLanguage('en-US')
 
-         let contextMenuBuilder = new ContextMenuBuilder(window.spellCheckHandler);
+    let contextMenuBuilder = new ContextMenuBuilder(window.spellCheckHandler)
 
-         let contextMenuListener = new ContextMenuListener((info) => {
-             contextMenuBuilder.showPopupMenu(info);
-         });
-       }
+    let contextMenuListener = new ContextMenuListener((info) => { // eslint-disable-line no-unused-vars
+      contextMenuBuilder.showPopupMenu(info)
+    })
+  }
 }
 
 window.addEventListener('DOMContentLoaded', handleDOMLoaded, false)
 window.addEventListener('click', handleClick, false)
-window.addEventListener('load', function () { loadSpellChecker() } );
+window.addEventListener('load', function () { loadSpellChecker() })
 ipc.on('navigate', handleNavigate)

--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
   "homepage": "https://github.com/andrepolischuk/keep",
   "dependencies": {
     "electron-config": "^1.0.0",
-    "electron-debug": "^1.0.1"
+    "electron-debug": "^1.0.1",
+    "electron-spellchecker": "^1.1.2"
   },
   "devDependencies": {
     "electron": "^1.4.4",
     "electron-packager": "^9.1.0",
+    "electron-rebuild": "^1.8.2",
     "standard": "^10.0.3"
   }
 }


### PR DESCRIPTION
Added spell-checking functionality using [electron-spellchecker](https://github.com/electron-userland/electron-spellchecker)

`sudo apt-get install libx11-dev libxkbfile-dev` is now needed for linux builds I think. I modified  
`.travis.yml` to deal with this change. Not sure if there is a better solution.

Should resolve #28