### PR TITLE
package.json: Add snap build for Linux.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "electron": "^3.0.7",
-    "electron-builder": "^20.29.0",
+    "electron-builder": "^20.39.0",
     "standard": "^10.0.3"
   },
   "build": {
@@ -75,7 +75,8 @@
       "category": "Utility",
       "target": [
         "AppImage",
-        "deb"
+        "deb",
+        "snap"
       ]
     },
     "win": {


### PR DESCRIPTION
Hey @andrepolischuk I work on the Snapcraft team and would love to help get Keep published in the [Snap Store](https://snapcraft.io/store), which is the app store for Linux :smiley: This pull request adds a snap to the Linux builds and bumps the `electron-builder` version which provides improved snap support.

Once published, you'll have direct control of the publishing life cycle, access to metrics for weekly active devices and users will get automatic updates. I see you're using Travis, here are the docs for publishing in the Snap Store.

  * https://docs.snapcraft.io/releasing-to-the-snap-store/6848
  * https://docs.travis-ci.com/user/deployment/snaps/

I'd love to feature Keep as an editors pick in the store and put together a social campaign to promote it. Is there any other help you need to get Keep published in the snap store?