### PR TITLE
Tray and window management

### DIFF
--- a/app/browser.js
+++ b/app/browser.js
@@ -44,6 +44,13 @@ function handleDOMLoaded () {
 function handleClick (event) {
   const node = event.target
 
+  if (node.closest('a').href.indexOf('?authuser=') > -1) {
+    // Link is to other account window.
+    console.log("Opening new account window.")
+    event.preventDefault()
+    ipc.send('newaccountwindow', node.closest('a').href)
+  }
+
   if (node.nodeName === 'A' && node.target === '_blank') {
     event.preventDefault()
     ipc.send('clicklink', node.href)

--- a/app/index.js
+++ b/app/index.js
@@ -1,23 +1,54 @@
 'use strict'
 const app = require('electron').app
 const ipc = require('electron').ipcMain
+const BrowserWindow = require('electron').BrowserWindow
 const shell = require('electron').shell
 const config = require('./config')
 const createMainMenu = require('./menu')
-const createMainWindow = require('./window')
+const createTrayMenu = require('./tray')
+const createMainWindow = require('./window').createMainWindow
+const createMainWindowWithUrl = require('./window').createMainWindowWithUrl
 
 require('electron-debug')()
 
-let mainWindow
+let windows = []
 
-function handleResize () {
-  if (!mainWindow.isFullScreen()) {
-    config.set('lastWindowState', mainWindow.getBounds())
+function handleResize (args) {
+  if (!args.sender.isFullScreen()) {
+    config.set('lastWindowState', args.sender.getBounds())
   }
 }
 
-function handleClosed () {
-  mainWindow = null
+function handleClosed (args) {
+  windows = windows.filter(function (value, index, array) {
+    try {
+      let test = value.id
+    }
+    catch(err) {
+      return false
+    }
+    return true
+  })
+}
+
+function hideAllWindows () {
+  windows.forEach((window) => {
+    window.hide()
+  })
+}
+
+function hideAllWindowsExcept (except) {
+  windows.forEach((window) => {
+    if (window.id !== except.id) {
+      window.hide()
+    }
+  })
+}
+
+function showAllWindows () {
+  windows.forEach((window) => {
+    window.show()
+  })
 }
 
 app.on('window-all-closed', () => {
@@ -29,17 +60,39 @@ app.on('window-all-closed', () => {
 })
 
 app.on('activate', () => {
-  if (!mainWindow) {
-    mainWindow = createMainWindow(handleResize, handleClosed)
+  if (!windows.length < 1) {
+    windows.push(createMainWindow(handleResize, handleClosed))
   }
-})
-
-app.on('ready', () => {
-  mainWindow = createMainWindow(handleResize, handleClosed)
-  createMainMenu()
 })
 
 ipc.on('clicklink', (event, url) => {
   event.preventDefault()
   shell.openExternal(url)
+})
+
+app.on('ready', () => {
+  windows.push(createMainWindow(handleResize, handleClosed))
+  createMainMenu()
+  createTrayMenu(hideAllWindows, showAllWindows)
+})
+
+app.on('hide-all', hideAllWindows)
+
+app.on('show-all', showAllWindows)
+
+app.on('hide-others', hideAllWindowsExcept)
+
+ipc.on('newaccountwindow', (event, url) => {
+  event.preventDefault()
+  // Checks if the window for the account is already open, and if so, shows it, and brings it into focus.
+  if (windows.filter(function (window) {
+    let testUrl = 'https://keep.google.com/u/' + (url.split('?authuser=')[1]) + '/'
+    if (window.webContents.getURL() == testUrl) {
+      window.show()
+      window.focus()
+      return true;
+    }
+  }).length < 1) {
+    windows.push(createMainWindowWithUrl(handleResize, handleClosed, url))
+  }
 })

--- a/app/index.js
+++ b/app/index.js
@@ -19,6 +19,14 @@ function handleResize (args) {
   }
 }
 
+function handleClose (event) {
+  if(windows.length < 2) {
+    // If this is the last window, hide instead of closing.
+    event.preventDefault();
+    event.sender.hide();
+  }
+}
+
 function handleClosed (args) {
   windows = windows.filter(function (value, index, array) {
     try {
@@ -51,18 +59,13 @@ function showAllWindows () {
   })
 }
 
-app.on('window-all-closed', () => {
-  if (process.platform === 'darwin') {
-    app.hide()
-  } else {
-    app.quit()
-  }
-})
+app.on('window-all-closed', e => e.preventDefault())
 
 app.on('activate', () => {
-  if (!windows.length < 1) {
-    windows.push(createMainWindow(handleResize, handleClosed))
+  if (windows.length < 1) {
+    windows.push(createMainWindow(handleResize, handleClose, handleClosed))
   }
+  showAllWindows()
 })
 
 ipc.on('clicklink', (event, url) => {
@@ -71,7 +74,7 @@ ipc.on('clicklink', (event, url) => {
 })
 
 app.on('ready', () => {
-  windows.push(createMainWindow(handleResize, handleClosed))
+  windows.push(createMainWindow(handleResize, handleClose, handleClosed))
   createMainMenu()
   createTrayMenu(hideAllWindows, showAllWindows)
 })
@@ -93,6 +96,6 @@ ipc.on('newaccountwindow', (event, url) => {
       return true;
     }
   }).length < 1) {
-    windows.push(createMainWindowWithUrl(handleResize, handleClosed, url))
+    windows.push(createMainWindowWithUrl(handleResize, handleClose, handleClosed, url))
   }
 })

--- a/app/menu.js
+++ b/app/menu.js
@@ -19,16 +19,25 @@ module.exports = function createMainMenu () {
         {
           label: 'Hide Keep',
           accelerator: 'Cmd+H',
-          role: 'hide'
+          role: 'hide',
+          click: () => {
+            app.emit('hide-all')
+          }
         },
         {
           label: 'Hide Others',
           accelerator: 'Alt+Cmd+H',
-          role: 'hideothers'
+          role: 'hideothers',
+          click: (item, win) => {
+            app.emit('hide-others', win)
+          }
         },
         {
           label: 'Show All',
-          role: 'unhide'
+          role: 'unhide',
+          click: () => {
+            app.emit('show-all')
+          }
         },
         {
           type: 'separator'

--- a/app/tray.js
+++ b/app/tray.js
@@ -1,11 +1,12 @@
 'use strict'
 const { app, Menu, Tray } = require('electron')
+const path = require('path')
 
 module.exports = function createTrayMenu (hideAllWindowsCallback, showAllWindowsCallback) {
   let tray = null
   app.whenReady().then(() => {
     console.log("Creating tray icon.")
-    tray = new Tray('./build/icon.png')
+    tray = new Tray(path.join(__dirname, '..', 'build','icon.png'))
     const contextMenu = Menu.buildFromTemplate([
       {
         label: 'Help',

--- a/app/tray.js
+++ b/app/tray.js
@@ -1,0 +1,51 @@
+'use strict'
+const { app, Menu, Tray } = require('electron')
+
+module.exports = function createTrayMenu (hideAllWindowsCallback, showAllWindowsCallback) {
+  let tray = null
+  app.whenReady().then(() => {
+    console.log("Creating tray icon.")
+    tray = new Tray('./build/icon.png')
+    const contextMenu = Menu.buildFromTemplate([
+      {
+        label: 'Help',
+        role: 'help',
+        submenu: [
+          {
+            label: 'View on GitHub',
+            click: () => {
+              shell.openExternal('http://github.com/andrepolischuk/keep')
+            }
+          }
+        ]
+      },
+      {
+        label: 'Hide Keep',
+        accelerator: 'Cmd+H',
+        role: 'hide',
+        click: () => {
+          hideAllWindowsCallback()
+        }
+      },
+      {
+        label: 'Show All',
+        role: 'unhide',
+        click: () => {
+          showAllWindowsCallback()
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Quit',
+        accelerator: 'Cmd+Q',
+        click: () => {
+          app.quit()
+        }
+      }
+    ])
+    tray.setToolTip('Google Keep')
+    tray.setContextMenu(contextMenu)
+  })
+}

--- a/app/tray.js
+++ b/app/tray.js
@@ -48,5 +48,8 @@ module.exports = function createTrayMenu (hideAllWindowsCallback, showAllWindows
     ])
     tray.setToolTip('Google Keep')
     tray.setContextMenu(contextMenu)
+    tray.on('double-click', (event, bounds) => {
+      app.emit('activate')
+    })
   })
 }

--- a/app/window.js
+++ b/app/window.js
@@ -4,10 +4,10 @@ const BrowserWindow = require('electron').BrowserWindow
 const config = require('./config')
 
 module.exports = {
-  createMainWindow: function (handleResize, handleClosed) {
-    return module.exports.createMainWindowWithUrl(handleResize, handleClosed, 'https://keep.google.com')
+  createMainWindow: function (handleResize, handleClose, handleClosed) {
+    return module.exports.createMainWindowWithUrl(handleResize, handleClose, handleClosed, 'https://keep.google.com')
   },
-  createMainWindowWithUrl: function (handleResize, handleClosed, url) {
+  createMainWindowWithUrl: function (handleResize, handleClose, handleClosed, url) {
     const lastWindowState = config.get('lastWindowState')
 
     const window = new BrowserWindow({
@@ -27,6 +27,7 @@ module.exports = {
     window.loadURL(url, {userAgent: 'Chrome'})
     window.on('resize', handleResize)
     window.on('closed', handleClosed)
+    window.on('close', handleClose)
 
     return window
   }

--- a/app/window.js
+++ b/app/window.js
@@ -3,26 +3,31 @@ const join = require('path').join
 const BrowserWindow = require('electron').BrowserWindow
 const config = require('./config')
 
-module.exports = function createMainWindow (handleResize, handleClosed) {
-  const lastWindowState = config.get('lastWindowState')
+module.exports = {
+  createMainWindow: function (handleResize, handleClosed) {
+    return module.exports.createMainWindowWithUrl(handleResize, handleClosed, 'https://keep.google.com')
+  },
+  createMainWindowWithUrl: function (handleResize, handleClosed, url) {
+    const lastWindowState = config.get('lastWindowState')
 
-  const window = new BrowserWindow({
-    minWidth: 615,
-    x: lastWindowState.x,
-    y: lastWindowState.y,
-    width: lastWindowState.width,
-    height: lastWindowState.height,
-    icon: join(__dirname, '../build/icon.png'),
-    title: 'Keep',
-    titleBarStyle: 'hiddenInset',
-    webPreferences: {
-      preload: `${__dirname}/browser.js`
-    }
-  })
+    const window = new BrowserWindow({
+      minWidth: 615,
+      x: lastWindowState.x,
+      y: lastWindowState.y,
+      width: lastWindowState.width,
+      height: lastWindowState.height,
+      icon: join(__dirname, '../build/icon.png'),
+      title: 'Keep',
+      titleBarStyle: 'hiddenInset',
+      webPreferences: {
+        preload: `${__dirname}/browser.js`
+      }
+    })
 
-  window.loadURL('https://keep.google.com', {userAgent: 'Chrome'})
-  window.on('resize', handleResize)
-  window.on('closed', handleClosed)
+    window.loadURL(url, {userAgent: 'Chrome'})
+    window.on('resize', handleResize)
+    window.on('closed', handleClosed)
 
-  return window
+    return window
+  }
 }


### PR DESCRIPTION
Exactly what the title says.
Adds the tray support requested in issue #27 as well as some relevant window management.
The app can now run entirely in the tray, getting it out of the way when not actively in use.
Semi dependent on PR #53, as the tray icon will not work in builds, due to the bug fixed by that PR.